### PR TITLE
Parse raw part when reading multipart childs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -180,7 +180,7 @@ func GetMultipartParts(r io.Reader, params map[string]string) (parts []io.Reader
 	headers = []textproto.MIMEHeader{}
 	var p *multipart.Part
 	for {
-		p, err = mr.NextPart()
+		p, err = mr.NextRawPart()
 		if err == io.EOF {
 			err = nil
 			break


### PR DESCRIPTION
As per the RFC

`If an entity is of type "multipart" the Content-Transfer-Encoding is not permitted to have any value other than "7bit", "8bit" or "binary".`

In order to avoid failing on messages that do not respect that convention, we can ignore the encoding for multiparts, and only apply the encoding of the subparts.