### PR TITLE
Fix insecure decoding of content.

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -1,7 +1,6 @@
 package gomime
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"mime"
@@ -11,9 +10,9 @@ import (
 	"unicode/utf8"
 
 	"encoding/base64"
+
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/htmlindex"
-	"golang.org/x/text/transform"
 )
 
 var wordDec = &mime.WordDecoder{
@@ -189,21 +188,13 @@ func DecodeCharset(original []byte, mediaType string, contentTypeParams map[stri
 		}
 		err = fmt.Errorf("non-utf8 content without charset specification")
 	}
-
 	if err != nil {
 		return original, err
 	}
-
-	utf8 := make([]byte, len(original))
-	nDst, nSrc, err := decoder.Transform(utf8, original, false)
-	for err == transform.ErrShortDst {
-		utf8 = make([]byte, (nDst/nSrc+1)*len(original))
-		nDst, nSrc, err = decoder.Transform(utf8, original, false)
-	}
+	utf8, err := decoder.Bytes(original)
 	if err != nil {
 		return original, err
 	}
-	utf8 = bytes.Trim(utf8, "\x00")
 
 	return utf8, nil
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -46,6 +46,17 @@ func TestDecodeHeader(t *testing.T) {
 	}
 }
 
+func TestDecodeCharsetBoundaryInputs(t *testing.T) {
+	_, err := DecodeCharset([]byte("\xff"), "text/plain", map[string]string{"charset": "csKOI8R"})
+	if err != nil {
+		t.Error("Expected no error")
+	}
+	_, err = DecodeCharset([]byte("+000000000000000000000000 "), "text/plain", map[string]string{"charset": "utf7"})
+	if err != nil {
+		t.Error("Expected no error")
+	}
+}
+
 func TestGetEncoding(t *testing.T) {
 	// all MIME charset with aliases can be found here https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	mimesets := map[string][]string{

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,7 +2,6 @@ package gomime
 
 import (
 	"bytes"
-	"fmt"
 
 	"io/ioutil"
 	"net/mail"
@@ -322,18 +321,8 @@ TqRoIApQlGggySjCNBAJQcgggEAIFqCCASAklqCCALT1TfhDdEgggNI9v1SXM/ugggjDmHqEEEEy
 
 
 `
-	body, heads, att, attHeads, err := androidParse(testMessage)
+	_, _, _, _, err := androidParse(testMessage)
 	if err != nil {
 		t.Error("parse error", err)
 	}
-
-	fmt.Println("==BODY:")
-	fmt.Println(body)
-	fmt.Println("==BODY HEADERS:")
-	fmt.Println(heads)
-
-	fmt.Println("==ATTACHMENTS:")
-	fmt.Println(att)
-	fmt.Println("==ATTACHMENT HEADERS:")
-	fmt.Println(attHeads)
 }


### PR DESCRIPTION
Use decoder.Bytes() to decode encoded content instead of insecure custom logic.